### PR TITLE
Support trailing commas

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -121,7 +121,10 @@ fn table(input: &str) -> IResult<&str, Value> {
     map(
         delimited(
             delimited(ws, char('{'), ws),
-            separated_list0(delimited(ws, char(','), ws), maybe_named_value),
+            terminated(
+                separated_list0(delimited(ws, char(','), ws), maybe_named_value),
+                opt(char(',')),
+            ),
             delimited(ws, char('}'), ws),
         ),
         |pairs| {
@@ -179,6 +182,14 @@ mod tests {
                 (Some("b".to_string()), Value::Float(6.))
             ],
             parse("{a=5,b=6}").unwrap()
+        );
+
+        assert_eq!(
+            vec![
+                (Some("a".to_string()), Value::Float(5.)),
+                (Some("b".to_string()), Value::Float(6.))
+            ],
+            parse("{a=5,b=6 ,}").unwrap()
         );
 
         assert_eq!(


### PR DESCRIPTION
**Summary**
I was trying to use this to parse a lua table from a fandom.com wiki, but it failed to parse due to trailing commas.

This patch allows tables to contain a value which is optionally terminated with a comma.

This is lua [docs](https://www.lua.org/pil/3.6.html) back this saying
> You can always put a comma after the last entry. These trailing commas are optional, but are always valid:

**Test plan**
I added a simple unit test so `cargo test` should suffice